### PR TITLE
Register storage containers for use on contraptions.

### DIFF
--- a/src/generated/resources/data/create/tags/block/simple_mounted_storage.json
+++ b/src/generated/resources/data/create/tags/block/simple_mounted_storage.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "dndecor:colored_storage_container"
+  ]
+}


### PR DESCRIPTION
Add the create:simple_mounted_storage tag to storage containers so they can be used in contraptions.