### PR TITLE
Added diagonal girder rotation & mirror methods

### DIFF
--- a/src/main/java/dev/lopyluna/dndecor/content/blocks/diagonal_girder/DiagonalGirderBlock.java
+++ b/src/main/java/dev/lopyluna/dndecor/content/blocks/diagonal_girder/DiagonalGirderBlock.java
@@ -118,6 +118,6 @@ public class DiagonalGirderBlock extends Block implements SimpleWaterloggedBlock
 
     @Override
     protected @NotNull BlockState mirror(BlockState state, Mirror mirror) {
-        return state.rotate(mirror.getRotation(state.getValue(DiagonalGirderBlock.FACING)));
+        return rotate(state, mirror.getRotation(state.getValue(DiagonalGirderBlock.FACING)));
     }
 }

--- a/src/main/java/dev/lopyluna/dndecor/content/blocks/diagonal_girder/DiagonalGirderBlock.java
+++ b/src/main/java/dev/lopyluna/dndecor/content/blocks/diagonal_girder/DiagonalGirderBlock.java
@@ -10,6 +10,8 @@ import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.SimpleWaterloggedBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
@@ -107,5 +109,15 @@ public class DiagonalGirderBlock extends Block implements SimpleWaterloggedBlock
         }
         if (clickedFace == Direction.DOWN) return defaultBlockState().setValue(FACING, facing).setValue(FACING_UP,true).setValue(WATERLOGGED, flag);
         return defaultBlockState().setValue(FACING, facing).setValue(FACING_UP,false).setValue(WATERLOGGED, flag);
+    }
+
+    @Override
+    protected @NotNull BlockState rotate(@NotNull BlockState state, @NotNull Rotation rot) {
+        return state.setValue(DiagonalGirderBlock.FACING, rot.rotate(state.getValue(DiagonalGirderBlock.FACING)));
+    }
+
+    @Override
+    protected @NotNull BlockState mirror(BlockState state, Mirror mirror) {
+        return state.rotate(mirror.getRotation(state.getValue(DiagonalGirderBlock.FACING)));
     }
 }


### PR DESCRIPTION
This allows schematics, worldedit and any nbt structure to correctly rotate & mirror the diagonal girders