### PR TITLE
Fix optional Dye Depot loot tables

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+
 plugins {
     id 'java-library'
     id 'eclipse'
@@ -42,6 +45,59 @@ runs {
 }
 
 sourceSets.main.resources { srcDir 'src/generated/resources' }
+
+def conditionDyeDepotLootTables = tasks.register('conditionDyeDepotLootTables') {
+    group = 'mod development'
+    description = 'Adds Dye Depot load conditions to generated loot tables for optional colors.'
+
+    def generatedData = layout.projectDirectory.dir('src/generated/resources/data/dndecor')
+    inputs.dir(generatedData.dir('recipe'))
+    inputs.dir(generatedData.dir('loot_table/blocks'))
+
+    doLast {
+        def recipeDir = generatedData.dir('recipe').asFile
+        def lootDir = generatedData.dir('loot_table/blocks').asFile
+        if (!recipeDir.isDirectory() || !lootDir.isDirectory()) return
+
+        def parser = new JsonSlurper()
+        def conditionalBlockIds = [] as Set
+        fileTree(recipeDir).matching { include '**/*.json' }.files.each { recipeFile ->
+            def recipe = parser.parse(recipeFile)
+            def requiresDyeDepot = recipe['neoforge:conditions']?.any {
+                it.type == 'neoforge:mod_loaded' && it.modid == 'dye_depot'
+            }
+            if (requiresDyeDepot && recipe.result?.id instanceof String) {
+                conditionalBlockIds.add(recipe.result.id)
+            }
+        }
+
+        conditionalBlockIds.each { blockId ->
+            def namespaceAndPath = blockId.split(':', 2)
+            if (namespaceAndPath.length != 2 || namespaceAndPath[0] != mod_id) return
+
+            def lootFile = new File(lootDir, "${namespaceAndPath[1]}.json")
+            if (!lootFile.isFile()) return
+
+            def lootTable = ['neoforge:conditions': [[
+                    type : 'neoforge:mod_loaded',
+                    modid: 'dye_depot'
+            ]]]
+            lootTable.putAll(parser.parse(lootFile))
+
+            def formatted = JsonOutput.prettyPrint(JsonOutput.toJson(lootTable))
+            def twoSpaceFormatted = formatted.readLines().collect { line ->
+                int indent = 0
+                while (indent < line.length() && line.charAt(indent) == ' ') indent++
+                (' ' * indent.intdiv(2)) + line.substring(indent)
+            }.join('\n') + '\n'
+            lootFile.setText(twoSpaceFormatted, 'UTF-8')
+        }
+    }
+}
+
+tasks.configureEach {
+    if (name == 'runData') finalizedBy conditionDyeDepotLootTables
+}
 
 configurations {
     runtimeClasspath.extendsFrom localRuntime

--- a/src/generated/resources/data/dndecor/loot_table/blocks/amber_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/amber_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/amber_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/amber_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/amber_dark_metal_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/amber_dark_metal_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/amber_dark_metal_plating.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/amber_dark_metal_plating.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/amber_display_board.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/amber_display_board.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/amber_flywheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/amber_flywheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/amber_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/amber_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/amber_large_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/amber_large_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/amber_large_fan.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/amber_large_fan.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/amber_large_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/amber_large_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/amber_large_metal_girder.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/amber_large_metal_girder.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/amber_sheet_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/amber_sheet_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/amber_small_deepslate_tiles.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/amber_small_deepslate_tiles.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/amber_stone_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/amber_stone_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/amber_velvet_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/amber_velvet_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/aqua_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/aqua_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/aqua_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/aqua_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/aqua_dark_metal_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/aqua_dark_metal_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/aqua_dark_metal_plating.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/aqua_dark_metal_plating.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/aqua_display_board.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/aqua_display_board.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/aqua_flywheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/aqua_flywheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/aqua_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/aqua_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/aqua_large_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/aqua_large_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/aqua_large_fan.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/aqua_large_fan.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/aqua_large_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/aqua_large_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/aqua_large_metal_girder.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/aqua_large_metal_girder.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/aqua_sheet_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/aqua_sheet_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/aqua_small_deepslate_tiles.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/aqua_small_deepslate_tiles.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/aqua_stone_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/aqua_stone_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/aqua_velvet_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/aqua_velvet_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/beige_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/beige_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/beige_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/beige_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/beige_dark_metal_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/beige_dark_metal_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/beige_dark_metal_plating.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/beige_dark_metal_plating.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/beige_display_board.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/beige_display_board.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/beige_flywheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/beige_flywheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/beige_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/beige_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/beige_large_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/beige_large_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/beige_large_fan.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/beige_large_fan.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/beige_large_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/beige_large_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/beige_large_metal_girder.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/beige_large_metal_girder.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/beige_sheet_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/beige_sheet_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/beige_small_deepslate_tiles.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/beige_small_deepslate_tiles.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/beige_stone_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/beige_stone_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/beige_velvet_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/beige_velvet_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/coral_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/coral_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/coral_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/coral_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/coral_dark_metal_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/coral_dark_metal_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/coral_dark_metal_plating.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/coral_dark_metal_plating.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/coral_display_board.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/coral_display_board.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/coral_flywheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/coral_flywheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/coral_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/coral_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/coral_large_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/coral_large_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/coral_large_fan.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/coral_large_fan.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/coral_large_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/coral_large_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/coral_large_metal_girder.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/coral_large_metal_girder.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/coral_sheet_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/coral_sheet_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/coral_small_deepslate_tiles.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/coral_small_deepslate_tiles.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/coral_stone_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/coral_stone_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/coral_velvet_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/coral_velvet_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/forest_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/forest_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/forest_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/forest_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/forest_dark_metal_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/forest_dark_metal_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/forest_dark_metal_plating.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/forest_dark_metal_plating.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/forest_display_board.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/forest_display_board.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/forest_flywheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/forest_flywheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/forest_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/forest_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/forest_large_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/forest_large_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/forest_large_fan.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/forest_large_fan.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/forest_large_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/forest_large_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/forest_large_metal_girder.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/forest_large_metal_girder.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/forest_sheet_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/forest_sheet_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/forest_small_deepslate_tiles.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/forest_small_deepslate_tiles.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/forest_stone_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/forest_stone_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/forest_velvet_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/forest_velvet_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/ginger_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/ginger_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/ginger_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/ginger_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/ginger_dark_metal_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/ginger_dark_metal_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/ginger_dark_metal_plating.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/ginger_dark_metal_plating.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/ginger_display_board.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/ginger_display_board.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/ginger_flywheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/ginger_flywheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/ginger_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/ginger_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/ginger_large_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/ginger_large_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/ginger_large_fan.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/ginger_large_fan.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/ginger_large_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/ginger_large_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/ginger_large_metal_girder.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/ginger_large_metal_girder.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/ginger_sheet_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/ginger_sheet_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/ginger_small_deepslate_tiles.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/ginger_small_deepslate_tiles.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/ginger_stone_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/ginger_stone_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/ginger_velvet_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/ginger_velvet_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/indigo_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/indigo_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/indigo_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/indigo_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/indigo_dark_metal_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/indigo_dark_metal_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/indigo_dark_metal_plating.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/indigo_dark_metal_plating.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/indigo_display_board.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/indigo_display_board.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/indigo_flywheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/indigo_flywheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/indigo_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/indigo_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/indigo_large_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/indigo_large_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/indigo_large_fan.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/indigo_large_fan.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/indigo_large_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/indigo_large_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/indigo_large_metal_girder.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/indigo_large_metal_girder.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/indigo_sheet_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/indigo_sheet_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/indigo_small_deepslate_tiles.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/indigo_small_deepslate_tiles.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/indigo_stone_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/indigo_stone_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/indigo_velvet_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/indigo_velvet_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/maroon_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/maroon_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/maroon_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/maroon_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/maroon_dark_metal_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/maroon_dark_metal_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/maroon_dark_metal_plating.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/maroon_dark_metal_plating.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/maroon_display_board.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/maroon_display_board.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/maroon_flywheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/maroon_flywheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/maroon_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/maroon_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/maroon_large_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/maroon_large_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/maroon_large_fan.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/maroon_large_fan.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/maroon_large_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/maroon_large_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/maroon_large_metal_girder.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/maroon_large_metal_girder.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/maroon_sheet_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/maroon_sheet_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/maroon_small_deepslate_tiles.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/maroon_small_deepslate_tiles.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/maroon_stone_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/maroon_stone_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/maroon_velvet_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/maroon_velvet_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/mint_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/mint_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/mint_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/mint_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/mint_dark_metal_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/mint_dark_metal_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/mint_dark_metal_plating.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/mint_dark_metal_plating.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/mint_display_board.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/mint_display_board.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/mint_flywheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/mint_flywheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/mint_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/mint_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/mint_large_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/mint_large_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/mint_large_fan.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/mint_large_fan.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/mint_large_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/mint_large_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/mint_large_metal_girder.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/mint_large_metal_girder.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/mint_sheet_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/mint_sheet_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/mint_small_deepslate_tiles.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/mint_small_deepslate_tiles.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/mint_stone_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/mint_stone_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/mint_velvet_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/mint_velvet_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/navy_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/navy_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/navy_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/navy_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/navy_dark_metal_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/navy_dark_metal_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/navy_dark_metal_plating.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/navy_dark_metal_plating.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/navy_display_board.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/navy_display_board.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/navy_flywheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/navy_flywheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/navy_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/navy_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/navy_large_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/navy_large_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/navy_large_fan.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/navy_large_fan.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/navy_large_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/navy_large_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/navy_large_metal_girder.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/navy_large_metal_girder.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/navy_sheet_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/navy_sheet_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/navy_small_deepslate_tiles.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/navy_small_deepslate_tiles.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/navy_stone_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/navy_stone_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/navy_velvet_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/navy_velvet_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/olive_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/olive_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/olive_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/olive_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/olive_dark_metal_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/olive_dark_metal_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/olive_dark_metal_plating.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/olive_dark_metal_plating.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/olive_display_board.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/olive_display_board.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/olive_flywheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/olive_flywheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/olive_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/olive_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/olive_large_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/olive_large_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/olive_large_fan.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/olive_large_fan.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/olive_large_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/olive_large_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/olive_large_metal_girder.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/olive_large_metal_girder.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/olive_sheet_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/olive_sheet_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/olive_small_deepslate_tiles.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/olive_small_deepslate_tiles.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/olive_stone_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/olive_stone_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/olive_velvet_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/olive_velvet_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/rose_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/rose_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/rose_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/rose_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/rose_dark_metal_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/rose_dark_metal_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/rose_dark_metal_plating.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/rose_dark_metal_plating.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/rose_display_board.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/rose_display_board.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/rose_flywheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/rose_flywheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/rose_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/rose_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/rose_large_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/rose_large_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/rose_large_fan.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/rose_large_fan.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/rose_large_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/rose_large_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/rose_large_metal_girder.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/rose_large_metal_girder.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/rose_sheet_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/rose_sheet_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/rose_small_deepslate_tiles.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/rose_small_deepslate_tiles.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/rose_stone_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/rose_stone_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/rose_velvet_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/rose_velvet_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/slate_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/slate_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/slate_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/slate_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/slate_dark_metal_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/slate_dark_metal_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/slate_dark_metal_plating.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/slate_dark_metal_plating.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/slate_display_board.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/slate_display_board.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/slate_flywheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/slate_flywheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/slate_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/slate_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/slate_large_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/slate_large_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/slate_large_fan.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/slate_large_fan.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/slate_large_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/slate_large_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/slate_large_metal_girder.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/slate_large_metal_girder.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/slate_sheet_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/slate_sheet_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/slate_small_deepslate_tiles.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/slate_small_deepslate_tiles.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/slate_stone_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/slate_stone_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/slate_velvet_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/slate_velvet_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/solid_amber_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/solid_amber_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/solid_aqua_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/solid_aqua_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/solid_beige_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/solid_beige_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/solid_coral_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/solid_coral_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/solid_forest_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/solid_forest_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/solid_ginger_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/solid_ginger_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/solid_indigo_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/solid_indigo_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/solid_maroon_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/solid_maroon_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/solid_mint_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/solid_mint_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/solid_navy_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/solid_navy_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/solid_olive_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/solid_olive_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/solid_rose_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/solid_rose_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/solid_slate_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/solid_slate_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/solid_tan_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/solid_tan_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/solid_teal_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/solid_teal_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/solid_verdant_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/solid_verdant_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/tan_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/tan_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/tan_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/tan_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/tan_dark_metal_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/tan_dark_metal_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/tan_dark_metal_plating.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/tan_dark_metal_plating.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/tan_display_board.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/tan_display_board.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/tan_flywheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/tan_flywheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/tan_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/tan_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/tan_large_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/tan_large_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/tan_large_fan.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/tan_large_fan.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/tan_large_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/tan_large_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/tan_large_metal_girder.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/tan_large_metal_girder.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/tan_sheet_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/tan_sheet_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/tan_small_deepslate_tiles.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/tan_small_deepslate_tiles.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/tan_stone_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/tan_stone_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/tan_velvet_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/tan_velvet_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/teal_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/teal_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/teal_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/teal_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/teal_dark_metal_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/teal_dark_metal_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/teal_dark_metal_plating.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/teal_dark_metal_plating.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/teal_display_board.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/teal_display_board.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/teal_flywheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/teal_flywheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/teal_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/teal_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/teal_large_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/teal_large_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/teal_large_fan.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/teal_large_fan.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/teal_large_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/teal_large_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/teal_large_metal_girder.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/teal_large_metal_girder.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/teal_sheet_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/teal_sheet_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/teal_small_deepslate_tiles.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/teal_small_deepslate_tiles.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/teal_stone_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/teal_stone_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/teal_velvet_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/teal_velvet_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/verdant_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/verdant_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/verdant_container.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/verdant_container.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/verdant_dark_metal_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/verdant_dark_metal_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/verdant_dark_metal_plating.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/verdant_dark_metal_plating.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/verdant_display_board.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/verdant_display_board.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/verdant_flywheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/verdant_flywheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/verdant_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/verdant_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/verdant_large_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/verdant_large_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/verdant_large_fan.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/verdant_large_fan.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/verdant_large_industrial_cogwheel.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/verdant_large_industrial_cogwheel.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/verdant_large_metal_girder.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/verdant_large_metal_girder.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/verdant_sheet_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/verdant_sheet_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/verdant_small_deepslate_tiles.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/verdant_small_deepslate_tiles.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/verdant_stone_metal.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/verdant_stone_metal.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {

--- a/src/generated/resources/data/dndecor/loot_table/blocks/verdant_velvet_block.json
+++ b/src/generated/resources/data/dndecor/loot_table/blocks/verdant_velvet_block.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "dye_depot"
+    }
+  ],
   "type": "minecraft:block",
   "pools": [
     {


### PR DESCRIPTION
## Summary
  fix #139 
  Adds neoforge:mod_loaded(dye_depot) conditions to all generated loot tables whose block recipes require Dye Depot.

  A Gradle task now derives the affected block IDs from conditional recipes and applies the same condition to their
  corresponding loot tables after runData.

## Validation
  - Verified 256 conditional recipe results.
  - Verified all 256 corresponding loot tables exist.
  - Verified all affected loot tables include the Dye Depot load condition.
  - Ran processResources compileJava.
  - Ran git diff --check.
